### PR TITLE
Add neon drift effect to portfolio and optimize performance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,6 @@ NEXT_PUBLIC_SITE_URL=http://localhost:3000
 # Future contact form (Resend) — not wired yet
 # RESEND_API_KEY=
 # CONTACT_TO_EMAIL=
+
+# Postgres database (Neon Database)
+DATABASE_URL='postgresql://username:password@host:port/database'

--- a/messages/en.json
+++ b/messages/en.json
@@ -112,7 +112,8 @@
     "title": "Portfolio",
     "description": "Choose a category or open a project page for details and images.",
     "filters": { "all": "All", "projects": "Projects", "react": "React" },
-    "readMore": "Read more"
+    "readMore": "Read more",
+    "neonDriftHint": "Also reachable site-wide via Shift + P"
   },
   "contact": {
     "title": "Contact",
@@ -242,6 +243,33 @@
   },
   "projects": {
     "items": {
+      "neon-drift": {
+        "title": "Neon Drift",
+        "subtitle": "Embedded arcade prototype",
+        "descriptionTitle": "Mission briefing",
+        "description": "Neon Drift is a browser-native survival shooter woven into this portfolio—not listed in navigation, not promoted elsewhere. It exists as a technical exercise in canvas rendering, lightweight post-processing, and real-time audio inside a production Next.js site.",
+        "teaser": "A classified signal inside the portfolio. No public route—only those who look closer.",
+        "badge": "Classified",
+        "cardCta": "Open dossier",
+        "signalId": "Signal · ND-Σ7",
+        "lede": "Survive the swarm. Build synergies. Outlast waves that never forgive hesitation.",
+        "briefingTitle": "Briefing",
+        "briefingExtra": "The experience ships as an easter egg: a discreet control in the corner of every page, and a direct launch from this dossier. Progress, high scores, and achievements stay on-device.",
+        "capabilitiesTitle": "Systems online",
+        "feature0": "Modular game architecture (simulation, combat, waves, bosses) with quality-scaled rendering",
+        "feature1": "Seven enemy archetypes, round-based escalation, and boss encounters with telegraphed patterns",
+        "feature2": "Roguelike draft upgrades, build synergies, local achievements, and run recap",
+        "feature3": "Adaptive visuals and HTML5 audio tuned for stable performance on the open web",
+        "accessLabel": "Clearance granted",
+        "launch": "Launch Neon Drift",
+        "launchHint": "WASD · mouse aim · Shift dash · P or Esc to pause",
+        "meta": [
+          { "label": "Category", "value": "Browser arcade / portfolio easter egg" },
+          { "label": "Stack", "value": "TypeScript · Canvas 2D · Next.js" },
+          { "label": "Status", "value": "Live on site · embedded" },
+          { "label": "Access", "value": "Shift + P anywhere · or launch below" }
+        ]
+      },
       "eternal-cry": {
         "title": "Eternal-Cry",
         "subtitle": "Video game",

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -112,7 +112,8 @@
     "title": "Portfolio",
     "description": "Valitse kategoria tai avaa projektin sivu nähdäksesi lisätiedot ja kuvat.",
     "filters": { "all": "Kaikki", "projects": "Projektit", "react": "React" },
-    "readMore": "Lue lisää"
+    "readMore": "Lue lisää",
+    "neonDriftHint": "Saatavilla myös sivustolla: Shift + P"
   },
   "contact": {
     "title": "Ota yhteyttä",
@@ -242,6 +243,33 @@
   },
   "projects": {
     "items": {
+      "neon-drift": {
+        "title": "Neon Drift",
+        "subtitle": "Upotettu arcade-prototyyppi",
+        "descriptionTitle": "Tehtäväselostus",
+        "description": "Neon Drift on selainpohjainen selviytymisshooter, joka on kudottu tähän portfolioon—ei navigaatiossa, ei muualla mainittuna. Se on tekninen toteutus canvas-renderöinnistä, kevyestä jälkikäsittelystä ja reaaliaikaisesta äänestä tuotantovalmiissa Next.js-sivustossa.",
+        "teaser": "Luokiteltu signaali portfolion sisällä. Ei julkista reittiä—vain ne, jotka katsovat tarkemmin.",
+        "badge": "Luottamuksellinen",
+        "cardCta": "Avaa tiedosto",
+        "signalId": "Signaali · ND-Σ7",
+        "lede": "Selviydy parvesta. Rakenna synergioita. Kestä aaltoja, jotka eivät anna epäröidä.",
+        "briefingTitle": "Selostus",
+        "briefingExtra": "Kokemus toimii easter egginä: huomaamaton ohjaus jokaisen sivun kulmassa ja suora käynnistys tästä tiedostosta. Edistyminen, huipputulokset ja saavutukset pysyvät laitteella.",
+        "capabilitiesTitle": "Järjestelmät käytössä",
+        "feature0": "Modulaarinen peliarkkitehtuuri (simulaatio, taistelu, aallot, pomot) laadun mukaan skaalautuvalla renderöinnillä",
+        "feature1": "Seitsemän vihutyyppiä, kierros-pohjainen eskalaatio ja pomotaistelut ennakoiduilla kuvioilla",
+        "feature2": "Roguelike-päivitysvalinnat, build-synergiat, paikalliset saavutukset ja run-yhteenveto",
+        "feature3": "Mukautuvat grafiikat ja HTML5-ääni, viritetty vakaaseen suorituskykyyn avoimessa verkossa",
+        "accessLabel": "Lupa myönnetty",
+        "launch": "Käynnistä Neon Drift",
+        "launchHint": "WASD · hiiren tähtäys · Shift dash · P tai Esc tauolle",
+        "meta": [
+          { "label": "Kategoria", "value": "Selainarcade / portfolio-easter egg" },
+          { "label": "Teknologia", "value": "TypeScript · Canvas 2D · Next.js" },
+          { "label": "Tila", "value": "Live sivustolla · upotettu" },
+          { "label": "Pääsy", "value": "Shift + P missä tahansa · tai käynnistä alta" }
+        ]
+      },
       "eternal-cry": {
         "title": "Eternal-Cry",
         "subtitle": "Videopeli",

--- a/public/images/portfolio/neon-drift-cover.svg
+++ b/public/images/portfolio/neon-drift-cover.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 900" fill="none" role="img" aria-label="Neon Drift">
+  <defs>
+    <radialGradient id="glow" cx="50%" cy="42%" r="55%">
+      <stop offset="0%" stop-color="#1a4a7a" stop-opacity="0.55"/>
+      <stop offset="100%" stop-color="#07080c" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="ship" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#5ec4ff"/>
+      <stop offset="100%" stop-color="#0563bb"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="900" fill="#07080c"/>
+  <rect width="1200" height="900" fill="url(#glow)"/>
+  <g stroke="#1e3a5f" stroke-width="1" opacity="0.35">
+    <path d="M0 150H1200M0 300H1200M0 450H1200M0 600H1200M0 750H1200"/>
+    <path d="M150 0V900M300 0V900M450 0V900M600 0V900M750 0V900M900 0V900M1050 0V900"/>
+  </g>
+  <circle cx="600" cy="400" r="180" stroke="#2a6cb8" stroke-width="1" opacity="0.25"/>
+  <circle cx="600" cy="400" r="120" stroke="#3b9eff" stroke-width="1" opacity="0.18"/>
+  <path d="M600 280 L640 420 L600 520 L560 420 Z" fill="url(#ship)" opacity="0.9"/>
+  <path d="M600 520 L600 560" stroke="#5ec4ff" stroke-width="3" stroke-linecap="round" opacity="0.5"/>
+  <text x="600" y="720" text-anchor="middle" fill="#5ec4ff" font-family="system-ui,sans-serif" font-size="28" font-weight="600" letter-spacing="0.35em" opacity="0.85">NEON DRIFT</text>
+</svg>

--- a/src/app/[locale]/portfolio/[slug]/page.tsx
+++ b/src/app/[locale]/portfolio/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import { ArrowLeft, ExternalLink } from "lucide-react";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { SiteFooter } from "@/components/layout/SiteFooter";
+import { NeonDriftProjectPage } from "@/components/portfolio/neon-drift/NeonDriftProjectPage";
 import { ProjectGallery } from "@/components/portfolio/ProjectGallery";
 import { Link } from "@/i18n/navigation";
 import { routing } from "@/i18n/routing";
@@ -53,6 +54,17 @@ export default async function ProjectPage({ params }: PageProps) {
   if (!project) notFound();
 
   const t = await getTranslations("projectPage");
+
+  if (slug === "neon-drift") {
+    return (
+      <>
+        <main className="section-padding mx-auto max-w-6xl">
+          <NeonDriftProjectPage project={project} />
+        </main>
+        <SiteFooter />
+      </>
+    );
+  }
 
   return (
     <>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -183,3 +183,51 @@ body {
 .arcade-overload-flash {
   animation: arcade-overload-flash 2.4s ease-out forwards;
 }
+
+/* Neon Drift portfolio visuals */
+@keyframes neon-drift-ring {
+  0%,
+  100% {
+    opacity: 0.3;
+  }
+  50% {
+    opacity: 0.7;
+  }
+}
+
+@keyframes neon-drift-ring-slow {
+  0%,
+  100% {
+    opacity: 0.15;
+  }
+  50% {
+    opacity: 0.35;
+  }
+}
+
+.neon-drift-grid {
+  background-image:
+    linear-gradient(rgba(59, 158, 255, 0.06) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(59, 158, 255, 0.06) 1px, transparent 1px);
+  background-size: 32px 32px;
+}
+
+.neon-drift-ring {
+  animation: neon-drift-ring 5s ease-in-out infinite;
+}
+
+.neon-drift-ring-slow {
+  animation: neon-drift-ring-slow 28s linear infinite;
+}
+
+.neon-drift-ship {
+  clip-path: polygon(50% 0%, 100% 72%, 50% 100%, 0% 72%);
+  box-shadow: 0 0 18px rgba(94, 196, 255, 0.45);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .neon-drift-ring,
+  .neon-drift-ring-slow {
+    animation: none;
+  }
+}

--- a/src/components/arcade/NeonDriftCanvas.tsx
+++ b/src/components/arcade/NeonDriftCanvas.tsx
@@ -289,7 +289,7 @@ export function NeonDriftCanvas({ active, onClose }: NeonDriftCanvasProps) {
   let overlay: React.ReactNode = null;
   if (phase === "ready") {
     overlay = (
-      <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-4 bg-black/55 px-6 text-center backdrop-blur-[2px]">
+      <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-4 bg-[#0a0b0f]/88 px-6 text-center">
         <p className="font-display text-3xl font-bold tracking-tight text-white sm:text-4xl">{t("title")}</p>
         <p className="max-w-sm text-sm text-white/70">{t("tagline")}</p>
         <button

--- a/src/components/arcade/PowerUpDraft.tsx
+++ b/src/components/arcade/PowerUpDraft.tsx
@@ -12,7 +12,7 @@ export function PowerUpDraft({ choices, onPick }: PowerUpDraftProps) {
   const t = useTranslations("arcade.powerUps");
 
   return (
-    <div className="pointer-events-auto absolute inset-0 flex flex-col items-center justify-center gap-6 bg-black/65 px-4 backdrop-blur-sm">
+    <div className="pointer-events-auto absolute inset-0 flex flex-col items-center justify-center gap-6 bg-[#0a0b0f]/92 px-4">
       <p className="font-display text-xl font-bold tracking-wide text-fuchsia-200 sm:text-2xl">
         {t("draftTitle")}
       </p>

--- a/src/components/portfolio/neon-drift/NeonDriftArt.tsx
+++ b/src/components/portfolio/neon-drift/NeonDriftArt.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+type NeonDriftArtProps = {
+  variant?: "card" | "hero";
+  className?: string;
+};
+
+/** Lightweight CSS art — no canvas, no blur filters. */
+export function NeonDriftArt({ variant = "card", className = "" }: NeonDriftArtProps) {
+  const hero = variant === "hero";
+
+  return (
+    <div
+      className={`neon-drift-art relative overflow-hidden bg-[#07080c] ${hero ? "min-h-[280px] sm:min-h-[360px]" : "h-full w-full"} ${className}`}
+      aria-hidden
+    >
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_50%_38%,rgba(26,74,122,0.45),transparent_62%)]" />
+      <div className="neon-drift-grid pointer-events-none absolute inset-0 opacity-[0.22]" />
+      <div className="neon-drift-ring pointer-events-none absolute left-1/2 top-[42%] h-[min(52vw,220px)] w-[min(52vw,220px)] -translate-x-1/2 -translate-y-1/2 rounded-full border border-primary/25" />
+      <div className="neon-drift-ring-slow pointer-events-none absolute left-1/2 top-[42%] h-[min(36vw,150px)] w-[min(36vw,150px)] -translate-x-1/2 -translate-y-1/2 rounded-full border border-sky-400/15" />
+      <div className="pointer-events-none absolute left-1/2 top-[42%] -translate-x-1/2 -translate-y-1/2">
+        <div
+          className={`neon-drift-ship bg-gradient-to-br from-sky-300 to-primary ${hero ? "h-16 w-10 sm:h-20 sm:w-12" : "h-12 w-8"}`}
+        />
+      </div>
+      {hero && (
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-24 bg-gradient-to-t from-[#07080c] to-transparent" />
+      )}
+      <div className="pointer-events-none absolute inset-x-0 bottom-4 text-center">
+        <span
+          className={`font-display font-semibold tracking-[0.32em] text-sky-300/80 ${hero ? "text-xs sm:text-sm" : "text-[10px]"}`}
+        >
+          NEON DRIFT
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/portfolio/neon-drift/NeonDriftPortfolioCard.tsx
+++ b/src/components/portfolio/neon-drift/NeonDriftPortfolioCard.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Link } from "@/i18n/navigation";
+import { NeonDriftArt } from "@/components/portfolio/neon-drift/NeonDriftArt";
+import type { ProjectMeta } from "@/types";
+
+type NeonDriftPortfolioCardProps = {
+  project: ProjectMeta;
+};
+
+export function NeonDriftPortfolioCard({ project }: NeonDriftPortfolioCardProps) {
+  const t = useTranslations("projects.items.neon-drift");
+  const tPortfolio = useTranslations("portfolio");
+
+  return (
+    <article className="neon-drift-card group relative overflow-hidden rounded-2xl border border-primary/20 bg-[#0a0b0f] shadow-sm transition hover:-translate-y-1 hover:border-primary/40 hover:shadow-[0_12px_40px_-12px_rgba(59,158,255,0.25)]">
+      <span className="absolute right-3 top-3 z-10 rounded-full border border-sky-400/25 bg-black/50 px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.2em] text-sky-300/90">
+        {t("badge")}
+      </span>
+      <div className="relative aspect-[4/3] overflow-hidden">
+        <NeonDriftArt variant="card" />
+      </div>
+      <div className="relative border-t border-primary/10 p-5">
+        <p className="text-[11px] font-medium uppercase tracking-[0.22em] text-sky-400/70">
+          {project.subtitle}
+        </p>
+        <h3 className="mt-1 font-display text-lg font-semibold text-white">{project.title}</h3>
+        <p className="mt-2 line-clamp-2 text-sm leading-relaxed text-white/55">{t("teaser")}</p>
+        <Link
+          href={`/portfolio/${project.slug}`}
+          className="mt-4 inline-flex items-center text-sm font-semibold text-sky-300 transition hover:text-sky-200"
+        >
+          {t("cardCta")}
+          <span className="ml-1 transition group-hover:translate-x-0.5" aria-hidden>
+            →
+          </span>
+        </Link>
+        <p className="mt-3 text-[10px] text-white/30">
+          {tPortfolio("neonDriftHint")}
+        </p>
+      </div>
+    </article>
+  );
+}

--- a/src/components/portfolio/neon-drift/NeonDriftProjectPage.tsx
+++ b/src/components/portfolio/neon-drift/NeonDriftProjectPage.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { ArrowLeft, Radio } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { useCallback, useState } from "react";
+import { NeonDriftArt } from "@/components/portfolio/neon-drift/NeonDriftArt";
+import { Link } from "@/i18n/navigation";
+import type { ProjectMeta } from "@/types";
+
+const NeonDriftCanvas = dynamic(
+  () => import("@/components/arcade/NeonDriftCanvas").then((m) => m.NeonDriftCanvas),
+  { ssr: false, loading: () => null },
+);
+
+type NeonDriftProjectPageProps = {
+  project: ProjectMeta;
+};
+
+export function NeonDriftProjectPage({ project }: NeonDriftProjectPageProps) {
+  const t = useTranslations("projects.items.neon-drift");
+  const tPage = useTranslations("projectPage");
+  const [open, setOpen] = useState(false);
+
+  const launch = useCallback(() => setOpen(true), []);
+  const close = useCallback(() => setOpen(false), []);
+
+  const features = ["feature0", "feature1", "feature2", "feature3"] as const;
+
+  return (
+    <>
+      <Link
+        href="/#portfolio"
+        className="mb-8 inline-flex items-center gap-2 text-sm font-medium text-primary hover:text-primary-hover"
+      >
+        <ArrowLeft className="h-4 w-4" aria-hidden />
+        {tPage("back")}
+      </Link>
+
+      <div className="overflow-hidden rounded-2xl border border-primary/15 bg-[#0a0b0f]">
+        <NeonDriftArt variant="hero" />
+        <div className="border-t border-primary/10 px-6 py-8 sm:px-10 sm:py-10">
+          <div className="flex flex-wrap items-center gap-3">
+            <span className="inline-flex items-center gap-1.5 rounded-full border border-sky-400/30 bg-sky-400/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-sky-300">
+              <Radio className="h-3 w-3" aria-hidden />
+              {t("badge")}
+            </span>
+            <span className="text-xs text-white/40">{t("signalId")}</span>
+          </div>
+          <p className="mt-4 text-sm font-medium uppercase tracking-[0.2em] text-sky-400/80">
+            {project.subtitle}
+          </p>
+          <h1 className="mt-2 font-display text-3xl font-bold tracking-tight text-white sm:text-4xl">
+            {project.title}
+          </h1>
+          <p className="mt-4 max-w-2xl text-sm leading-relaxed text-white/60 sm:text-base">
+            {t("lede")}
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-10 grid gap-8 lg:grid-cols-[1.15fr_0.85fr]">
+        <div className="space-y-6">
+          <section className="rounded-2xl border border-border bg-surface p-6 sm:p-8">
+            <h2 className="font-display text-lg font-semibold text-foreground">{t("briefingTitle")}</h2>
+            <div className="mt-4 space-y-4 text-sm leading-relaxed text-secondary sm:text-base">
+              <p>{project.description}</p>
+              <p className="text-secondary/90">{t("briefingExtra")}</p>
+            </div>
+          </section>
+
+          <section className="rounded-2xl border border-border bg-surface p-6 sm:p-8">
+            <h2 className="font-display text-lg font-semibold text-foreground">{t("capabilitiesTitle")}</h2>
+            <ul className="mt-4 space-y-3">
+              {features.map((key) => (
+                <li
+                  key={key}
+                  className="flex gap-3 text-sm text-secondary before:mt-2 before:block before:h-1 before:w-1 before:shrink-0 before:rounded-full before:bg-primary before:content-['']"
+                >
+                  {t(key)}
+                </li>
+              ))}
+            </ul>
+          </section>
+        </div>
+
+        <aside className="space-y-6">
+          <div className="rounded-2xl border border-border bg-surface p-6">
+            <h2 className="font-display text-lg font-semibold text-foreground">{tPage("details")}</h2>
+            <dl className="mt-4 space-y-3">
+              {project.meta.map((row) => (
+                <div key={row.label} className="border-b border-border pb-3 last:border-0 last:pb-0">
+                  <dt className="text-xs font-semibold uppercase tracking-wide text-secondary">
+                    {row.label}
+                  </dt>
+                  <dd className="mt-1 text-sm text-foreground">{row.value}</dd>
+                </div>
+              ))}
+            </dl>
+          </div>
+
+          <div className="rounded-2xl border border-primary/20 bg-[#0a0b0f] p-6 text-center">
+            <p className="text-xs uppercase tracking-[0.2em] text-sky-400/70">{t("accessLabel")}</p>
+            <button
+              type="button"
+              onClick={launch}
+              className="mt-4 w-full rounded-full bg-primary px-6 py-3 text-sm font-semibold text-white shadow-md shadow-primary/30 transition hover:bg-primary-hover focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+            >
+              {t("launch")}
+            </button>
+            <p className="mt-3 text-xs text-white/45">{t("launchHint")}</p>
+          </div>
+        </aside>
+      </div>
+
+      {open && (
+        <div
+          className="dark fixed inset-0 z-[100] bg-[#0a0b0d]"
+          role="dialog"
+          aria-modal="true"
+          aria-label={project.title}
+        >
+          <NeonDriftCanvas active={open} onClose={close} />
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/sections/Portfolio.tsx
+++ b/src/components/sections/Portfolio.tsx
@@ -5,8 +5,11 @@ import { useMessages, useTranslations } from "next-intl";
 import { useMemo, useState } from "react";
 import { SectionHeading } from "@/components/ui/SectionHeading";
 import { Link } from "@/i18n/navigation";
+import { NeonDriftPortfolioCard } from "@/components/portfolio/neon-drift/NeonDriftPortfolioCard";
 import { getProjectsFromMessages } from "@/lib/projects";
 import type { ProjectCategory } from "@/types";
+
+const NEON_DRIFT_SLUG = "neon-drift";
 
 export function Portfolio() {
   const t = useTranslations("portfolio");
@@ -48,6 +51,9 @@ export function Portfolio() {
         <ul className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
           {filtered.map((project) => (
             <li key={project.slug}>
+              {project.slug === NEON_DRIFT_SLUG ? (
+                <NeonDriftPortfolioCard project={project} />
+              ) : (
               <article className="group overflow-hidden rounded-2xl border border-border bg-surface shadow-sm transition hover:-translate-y-1 hover:shadow-lg">
                 <div className="relative aspect-[4/3] overflow-hidden bg-surface-muted">
                   <Image
@@ -74,6 +80,7 @@ export function Portfolio() {
                   </Link>
                 </div>
               </article>
+              )}
             </li>
           ))}
         </ul>

--- a/src/content/projects-base.ts
+++ b/src/content/projects-base.ts
@@ -9,6 +9,15 @@ export type ProjectBase = {
 
 export const projectBases: ProjectBase[] = [
   {
+    slug: "neon-drift",
+    category: "projects",
+    coverImage: "/images/portfolio/neon-drift-cover.svg",
+    images: [
+      "/images/portfolio/neon-drift-cover.svg",
+      "/images/portfolio/neon-drift-cover.svg",
+    ],
+  },
+  {
     slug: "eternal-cry",
     category: "projects",
     coverImage: "/images/portfolio/Eternal-Cry.webp",
@@ -72,6 +81,7 @@ export const projectMetaLinks: Record<
   string,
   { href?: string; value: string }[]
 > = {
+  "neon-drift": [],
   "eternal-cry": [
     { value: "eternalcry.000webhostapp.com", href: "https://eternalcry.000webhostapp.com" },
   ],

--- a/src/lib/arcade/game/NeonDriftGame.ts
+++ b/src/lib/arcade/game/NeonDriftGame.ts
@@ -41,8 +41,12 @@ export class NeonDriftGame {
   private cb: NeonDriftCallbacks;
   private highScore = 0;
   private raf = 0;
+  private idleTimer = 0;
   private last = 0;
   private acc = 0;
+  /** Skip redraw while draft/pause overlay is up (canvas frozen). */
+  private overlayFrozen = false;
+  private renderDirty = true;
 
   constructor(
     canvas: HTMLCanvasElement,
@@ -168,6 +172,7 @@ export class NeonDriftGame {
     this.canvas.width = Math.floor(this.world.w * dpr);
     this.canvas.height = Math.floor(this.world.h * dpr);
     this.ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    this.renderDirty = true;
     this.renderer.resize(this.world, dpr);
     if (this.world.phase === "ready") {
       this.world.player.x = this.world.w / 2;
@@ -258,39 +263,51 @@ export class NeonDriftGame {
     this.start();
   }
 
+  private scheduleLoop() {
+    const profile = this.renderer.getProfile(this.world.phase);
+    const idle = (profile === "menu" || profile === "snapshot") && !this.renderDirty;
+    if (idle) {
+      this.idleTimer = window.setTimeout(() => this.loopFrame(performance.now()), 400);
+    } else {
+      this.raf = requestAnimationFrame(() => this.loopFrame(performance.now()));
+    }
+  }
+
+  private loopFrame(now: number) {
+    let dt = (now - this.last) / 1000;
+    this.last = now;
+    dt = Math.min(dt, 0.05);
+    const simulating =
+      this.world.phase === "playing" ||
+      this.world.phase === "bossFight" ||
+      this.world.phase === "bossIntro";
+    if (simulating && this.world.phase !== "bossIntro") {
+      const slow = this.world.hitSlowTimer > 0 ? 0.32 : 1;
+      if (this.world.hitSlowTimer > 0)
+        this.world.hitSlowTimer = Math.max(0, this.world.hitSlowTimer - dt);
+      const simDt = dt * slow;
+      this.world.audio.tick(simDt);
+      this.acc += simDt;
+      while (this.acc >= SIM_STEP) {
+        this.simTick(SIM_STEP);
+        this.acc -= SIM_STEP;
+      }
+    } else if (this.world.phase === "bossIntro") {
+      this.world.audio.tick(dt);
+      this.simTick(dt);
+    }
+    this.paintFrame(dt);
+    this.scheduleLoop();
+  }
+
   run() {
     this.last = performance.now();
-    const loop = (now: number) => {
-      this.raf = requestAnimationFrame(loop);
-      let dt = (now - this.last) / 1000;
-      this.last = now;
-      dt = Math.min(dt, 0.05);
-      const simulating =
-        this.world.phase === "playing" ||
-        this.world.phase === "bossFight" ||
-        this.world.phase === "bossIntro";
-      if (simulating && this.world.phase !== "bossIntro") {
-        const slow = this.world.hitSlowTimer > 0 ? 0.32 : 1;
-        if (this.world.hitSlowTimer > 0)
-          this.world.hitSlowTimer = Math.max(0, this.world.hitSlowTimer - dt);
-        const simDt = dt * slow;
-        this.world.audio.tick(simDt);
-        this.acc += simDt;
-        while (this.acc >= SIM_STEP) {
-          this.simTick(SIM_STEP);
-          this.acc -= SIM_STEP;
-        }
-      } else if (this.world.phase === "bossIntro") {
-        this.world.audio.tick(dt);
-        this.simTick(dt);
-      }
-      this.renderer.draw(this.world, dt, this.ctx);
-    };
-    this.raf = requestAnimationFrame(loop);
+    this.scheduleLoop();
   }
 
   destroy() {
     cancelAnimationFrame(this.raf);
+    if (this.idleTimer) window.clearTimeout(this.idleTimer);
     this.resetWorld();
   }
 
@@ -305,8 +322,38 @@ export class NeonDriftGame {
   }
 
   private emit() {
+    const wasFrozen = this.overlayFrozen;
+    const profile = this.renderer.getProfile(this.world.phase);
+    this.overlayFrozen = profile === "snapshot";
+    if (profile === "snapshot" && !wasFrozen) this.renderDirty = true;
+    if (profile === "menu" || profile === "full") this.renderDirty = true;
     this.cb.onStats(this.getStats());
     this.cb.onPhase(this.world.phase);
+  }
+
+  private paintFrame(dt: number) {
+    const profile = this.renderer.getProfile(this.world.phase);
+
+    if (profile === "snapshot") {
+      if (this.renderDirty) {
+        this.renderer.draw(this.world, dt, this.ctx, "full");
+        this.renderDirty = false;
+      }
+      return;
+    }
+
+    this.overlayFrozen = false;
+
+    if (profile === "menu") {
+      if (this.renderDirty) {
+        this.renderer.draw(this.world, dt, this.ctx, "menu");
+        this.renderDirty = false;
+      }
+      return;
+    }
+
+    this.renderDirty = true;
+    this.renderer.draw(this.world, dt, this.ctx, "full");
   }
 
   private addScore(n: number) {

--- a/src/lib/arcade/render/Renderer.ts
+++ b/src/lib/arcade/render/Renderer.ts
@@ -6,10 +6,20 @@ import {
 import type { GameWorld } from "@/lib/arcade/game/world";
 import { createBgCache, type BgGradientCache } from "@/lib/arcade/render/bg-cache";
 import { drawBackground, decayShake, getShakeOffset } from "@/lib/arcade/render/drawBackground";
+import { drawMenuScene } from "@/lib/arcade/render/drawMenu";
 import { drawChromaticShip, drawShip } from "@/lib/arcade/render/drawShip";
 import { drawOverlays, drawWorldLayer } from "@/lib/arcade/render/drawWorld";
 import { BloomPass } from "@/lib/arcade/render/postfx/bloom";
 import { parseColor } from "@/lib/arcade/utils/color";
+import type { GamePhase } from "@/lib/arcade/types";
+
+export type DrawProfile = "full" | "menu" | "snapshot";
+
+function profileForPhase(phase: GamePhase): DrawProfile {
+  if (phase === "ready") return "menu";
+  if (phase === "draft" || phase === "paused" || phase === "gameover") return "snapshot";
+  return "full";
+}
 
 export class Renderer {
   private bloom = new BloomPass();
@@ -17,7 +27,6 @@ export class Renderer {
   private qualitySetting: VisualQuality = "auto";
   private resolvedQuality: Exclude<VisualQuality, "auto"> = "medium";
   private bgCache: BgGradientCache | null = null;
-  private dpr = 1;
 
   constructor() {
     this.qualitySetting = loadVisualQuality();
@@ -41,7 +50,6 @@ export class Renderer {
   }
 
   resize(world: GameWorld, dpr = 1) {
-    this.dpr = dpr;
     this.resolvedQuality = resolveVisualQuality(
       this.qualitySetting,
       world.w,
@@ -52,15 +60,22 @@ export class Renderer {
       this.bloom.setTier(this.resolvedQuality);
       this.bloom.resize(world.w, world.h);
     }
-    const cacheCtx = this.bloom.getSceneCtx();
-    this.bgCache = createBgCache(cacheCtx, world.w, world.h);
+    const cacheCtx =
+      this.resolvedQuality === "off"
+        ? null
+        : this.bloom.getSceneCtx();
+    if (cacheCtx) this.bgCache = createBgCache(cacheCtx, world.w, world.h);
+    else {
+      const tmp = document.createElement("canvas").getContext("2d");
+      if (tmp) this.bgCache = createBgCache(tmp, world.w, world.h);
+    }
   }
 
-  private drawScene(
-    ctx: CanvasRenderingContext2D,
-    world: GameWorld,
-    dt: number,
-  ) {
+  getProfile(phase: GamePhase) {
+    return profileForPhase(phase);
+  }
+
+  private drawFullScene(ctx: CanvasRenderingContext2D, world: GameWorld, dt: number) {
     decayShake(world, dt);
     const shake = getShakeOffset(world);
     const pulse = world.beat.pulse();
@@ -91,25 +106,34 @@ export class Renderer {
     drawOverlays(ctx, world, primary, fg, showWorld, playing);
     ctx.restore();
 
-    const bloomIntensity =
-      this.resolvedQuality === "off" ? 0 : 0.28 + pulse * 0.2 + bass * 0.12;
-    return bloomIntensity;
+    return this.resolvedQuality === "off" ? 0 : 0.28 + pulse * 0.2 + bass * 0.12;
   }
 
-  /** Draw frame; composites to `target` when bloom is enabled. */
-  draw(world: GameWorld, dt: number, target: CanvasRenderingContext2D) {
-    if (this.resolvedQuality === "off") {
-      const intensity = this.drawScene(target, world, dt);
-      return intensity;
+  /**
+   * @param profile `snapshot` = one gameplay frame (draft/pause overlay). `menu` = static cheap UI bg.
+   */
+  draw(
+    world: GameWorld,
+    dt: number,
+    target: CanvasRenderingContext2D,
+    profile: DrawProfile = "full",
+  ) {
+    if (this.documentHidden && profile !== "menu") return;
+
+    if (profile === "menu") {
+      drawMenuScene(target, world, this.bgCache);
+      return;
+    }
+
+    const useBloom = this.resolvedQuality !== "off" && profile === "full";
+
+    if (!useBloom) {
+      this.drawFullScene(target, world, dt);
+      return;
     }
 
     const scene = this.bloom.getSceneCtx();
-    const intensity = this.drawScene(scene, world, dt);
-    if (this.documentHidden) {
-      target.drawImage(this.bloom.getSceneCanvas(), 0, 0, world.w, world.h);
-    } else {
-      this.bloom.composite(target, intensity, false);
-    }
-    return intensity;
+    const intensity = this.drawFullScene(scene, world, dt);
+    this.bloom.composite(target, intensity, false);
   }
 }

--- a/src/lib/arcade/render/drawMenu.ts
+++ b/src/lib/arcade/render/drawMenu.ts
@@ -1,0 +1,48 @@
+import type { BgGradientCache } from "@/lib/arcade/render/bg-cache";
+import type { GameWorld } from "@/lib/arcade/game/world";
+import { drawShip } from "@/lib/arcade/render/drawShip";
+import { parseColor } from "@/lib/arcade/utils/color";
+
+/** Cheap static backdrop for ready / gameover — no bloom, no animated grid. */
+export function drawMenuScene(
+  ctx: CanvasRenderingContext2D,
+  world: GameWorld,
+  bgCache: BgGradientCache | null,
+) {
+  const primary = parseColor(world.colors.primary, "#0563bb");
+  const fg = parseColor(world.colors.foreground, "#e8eaed");
+
+  ctx.setTransform(1, 0, 0, 1, 0, 0);
+  ctx.fillStyle = `hsl(${world.bgHue}, 22%, 7%)`;
+  ctx.fillRect(0, 0, world.w, world.h);
+
+  for (const s of world.stars) {
+    const alpha = (0.02 + s.z * 0.04) * (0.6 + s.layer * 0.1);
+    ctx.fillStyle = `hsla(${s.hue}, 35%, 70%, ${alpha})`;
+    ctx.fillRect(s.x * world.w, s.y * world.h, s.s, s.s);
+  }
+
+  if (bgCache) {
+    ctx.globalAlpha = 0.85;
+    ctx.fillStyle = bgCache.vignette;
+    ctx.fillRect(0, 0, world.w, world.h);
+    ctx.globalAlpha = 1;
+  }
+
+  ctx.strokeStyle = "rgba(90, 140, 200, 0.04)";
+  ctx.lineWidth = 1;
+  const grid = 48;
+  ctx.beginPath();
+  for (let x = 0; x < world.w; x += grid) {
+    ctx.moveTo(x, 0);
+    ctx.lineTo(x, world.h);
+  }
+  for (let y = 0; y < world.h; y += grid) {
+    ctx.moveTo(0, y);
+    ctx.lineTo(world.w, y);
+  }
+  ctx.stroke();
+
+  const showShip = world.phase === "ready" || world.phase === "gameover";
+  drawShip(ctx, world, primary, fg, world.phase, showShip);
+}


### PR DESCRIPTION
This pull request introduces a new "Neon Drift" embedded arcade project as a portfolio easter egg, with full internationalization support, dedicated UI components, and custom visuals. It adds special handling for this project in the portfolio grid and project page, including a custom card, hero section, and a launchable game modal. Additionally, it updates translations and environment configuration for completeness.

**Neon Drift Project Integration**

- Added "Neon Drift" as a new project in the portfolio, including metadata, images, and a dedicated entry in `projectBases` and `projectMetaLinks`. [[1]](diffhunk://#diff-dba413387c50cd04d0117799e8fe4fb2e5807aaf3aad629e83b7657e9758ff74R11-R19) [[2]](diffhunk://#diff-dba413387c50cd04d0117799e8fe4fb2e5807aaf3aad629e83b7657e9758ff74R84)
- Implemented a custom card component (`NeonDriftPortfolioCard`) and hero art (`NeonDriftArt`) for "Neon Drift", and integrated them into the portfolio grid to replace the default card for this project. [[1]](diffhunk://#diff-530a7a61b83659397b47de3d67236c652b9271ac378e4a9b425090fb78ad5d8dR1-R45) [[2]](diffhunk://#diff-4d7da91f097de8a773e0e3fcafe590066666c25253ba98ed32bbbcb03cb680feR8-R13) [[3]](diffhunk://#diff-4d7da91f097de8a773e0e3fcafe590066666c25253ba98ed32bbbcb03cb680feR54-R56) [[4]](diffhunk://#diff-4d7da91f097de8a773e0e3fcafe590066666c25253ba98ed32bbbcb03cb680feR83)
- Created a dedicated project page component (`NeonDriftProjectPage`) with custom layout, feature list, and a button to launch the embedded arcade game in a modal. Routing logic in `[slug]/page.tsx` was updated to use this component for the "neon-drift" slug. ([src/components/portfolio/neon-drift/NeonDriftProjectPage.tsxR1-R128](diffhunk://#diff-2a3f6bd26711c8eb7a5e9aa2246407ba74a27e857b807845e627c4b82e0d0c5aR1-R128), [src/app/[locale]/portfolio/[slug]/page.tsxR7](diffhunk://#diff-f6f308b0bbe230e32709a701003fc23b17681a3e52d915a46a147b5c8d677a4fR7), [src/app/[locale]/portfolio/[slug]/page.tsxR58-R68](diffhunk://#diff-f6f308b0bbe230e32709a701003fc23b17681a3e52d915a46a147b5c8d677a4fR58-R68))

**UI/Visual Enhancements**

- Added custom CSS for "Neon Drift" visuals, including animated backgrounds, grid, ring effects, and ship art, with reduced motion support. [[1]](diffhunk://#diff-4f206759c961f544a48464ad2ee231adc87e72593d03a0004b68c17771f7a412R186-R233) [[2]](diffhunk://#diff-f393ac228fc8f9964914a9315d515976ca1c7d1ee3c85bbd305aa10e7a9f5120R1-R38)
- Improved overlay backgrounds for the arcade canvas and power-up draft to use a more thematic color scheme. [[1]](diffhunk://#diff-eea2ebcad1c7c595d316af6674fcf36b8e5c065e34f732e4e6af4039599bc655L292-R292) [[2]](diffhunk://#diff-d88ad143baf44ca2ceeeced0c3b261c2b359be2ed0703fd62ea435fd08d1797dL15-R15)

**Internationalization and Messaging**

- Added comprehensive English and Finnish translations for "Neon Drift", including project details, UI hints, and feature descriptions. [[1]](diffhunk://#diff-5d9e5048516ec2fe83ca06813e79c3b8b44c6c96294f25c7311db311e28eeaeeL115-R116) [[2]](diffhunk://#diff-5d9e5048516ec2fe83ca06813e79c3b8b44c6c96294f25c7311db311e28eeaeeR246-R272) [[3]](diffhunk://#diff-48eb5322cd2d505aeaef97051c94a8184fed07c3a87103d0a3e2a581b29073ebL115-R116) [[4]](diffhunk://#diff-48eb5322cd2d505aeaef97051c94a8184fed07c3a87103d0a3e2a581b29073ebR246-R272)

**Configuration**

- Added a placeholder for the Postgres database connection string in `.env.example` for future backend/database support.